### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ Full DFZ (1154968 total, 202729 aggregates):
 
 IPv4 DFZ (968520 total, 154061 aggregates):
 ![ipv4 dfz perf comparison](doc/perfcomp_v4.png)
+
+## Installation
+
+### FreeBSD
+
+```
+pkg install rs-aggregate
+```
+
+### Others
+
+```
+cargo install rs-aggregate
+```


### PR DESCRIPTION
I've created a FreeBSD port that's in the official port collection now. These changes reflect that and also add general cargo install instructions, which are not all too obvious for users.